### PR TITLE
Retorno da função de leitura readDIP() adicionado.

### DIFF
--- a/MiniSumoAuto.ino
+++ b/MiniSumoAuto.ino
@@ -158,4 +158,5 @@ int readDIP(){
     n|= (1<<2);
   if(digitalRead(DIP1)==HIGH)
     n|= (1<<3);
+  return n;
 }


### PR DESCRIPTION
A função de leitura do DIPSwitch não tinha retorno do valor setado.